### PR TITLE
[09/11] Changements dans le code

### DIFF
--- a/CityProject/CityProject.pro.user
+++ b/CityProject/CityProject.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.7.1, 2018-11-02T14:19:25. -->
+<!-- Written by QtCreator 4.7.1, 2018-11-09T12:40:13. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/CityProject/baseglwidget.cpp
+++ b/CityProject/baseglwidget.cpp
@@ -51,7 +51,6 @@ void baseGLWidget::perspectiveGL( GLdouble fovY, GLdouble aspect, GLdouble zNear
     const GLdouble pi = 3.1415926535897932384626433832795;
     GLdouble fW, fH;
 
-    //fH = tan( (fovY / 2) / 180 * pi ) * zNear;
     fH = tan( fovY / 360 * pi ) * zNear;
     fW = fH * aspect;
 

--- a/CityProject/building.cpp
+++ b/CityProject/building.cpp
@@ -14,3 +14,21 @@ int Building::getHeight(){
 int Building::getWidth(){
     return width;
 }
+
+float Building::getSurfaceX(){
+    return posX;
+}
+
+float Building::getSurfaceY(){
+    return posY;
+}
+
+float Building::getSurfaceZ(){
+    return posZ;
+}
+
+void Building::setSurfacePosition(float x, float y, float z){
+    posX = x;
+    posY = y;
+    posZ = z;
+}

--- a/CityProject/building.h
+++ b/CityProject/building.h
@@ -11,6 +11,7 @@ class Building
 private :
     int height; // hauteur du bâtiment (m)
     int width;  // largeur du bâtiment (m)
+    float posX, posY, posZ; //Position of center of building on city surface.
 public :
     // On laisse aux classes filles le soin de déclarer cette fonction, car elle diffère selon
     // la forme générale du bâtiment (carrée, circulaire, ...)
@@ -18,6 +19,10 @@ public :
     Building(int minh, int maxh, int minw, int maxw);
     int getHeight();
     int getWidth();
+    float getSurfaceX();
+    float getSurfaceY();
+    float getSurfaceZ();
+    void setSurfacePosition(float x, float y, float z);
 };
 
 #endif // BUILDING_H

--- a/CityProject/house.h
+++ b/CityProject/house.h
@@ -6,7 +6,6 @@
 class House : public SquaredBuilding
 {
 private :
-
 public:
     House();
 };

--- a/CityProject/mainwindow.cpp
+++ b/CityProject/mainwindow.cpp
@@ -15,11 +15,11 @@ MainWindow::~MainWindow()
 
 void MainWindow::on_actionBuildingWin_triggered()
 {
-    qDebug("loulilol");
-    House h = House();
-    h.setSurfacePosition(0,0,0);
-    testWindow * bwin = new testWindow();
-    bwin->setAttribute(Qt::WA_DeleteOnClose);
-    bwin->loadBuilding(h);
-    bwin->show();
+    if(twin != NULL) twin->close();
+    twin = new testWindow();
+    Building * h = new Tower();
+    h->setSurfacePosition(0,0,0);
+    twin->setAttribute(Qt::WA_DeleteOnClose);
+    twin->loadBuilding(h);
+    twin->show();
 }

--- a/CityProject/mainwindow.h
+++ b/CityProject/mainwindow.h
@@ -24,6 +24,7 @@ private slots:
 
 private:
     Ui::MainWindow *ui;
+    testWindow * twin;
 };
 
 #endif // MAINWINDOW_H

--- a/CityProject/squaredbuilding.cpp
+++ b/CityProject/squaredbuilding.cpp
@@ -6,10 +6,12 @@ SquaredBuilding::SquaredBuilding(int minh, int maxh, int minw, int maxw) : Build
 }
 
 void SquaredBuilding::generateBuilding(){
-    float minl = posX, maxl = posX + getWidth();
-    float minh = posY, maxh = posY + getHeight();
-    float minp = posZ, maxp = posZ + getWidth();
-    glLoadIdentity();
+    float posX = getSurfaceX();
+    float posY = getSurfaceY();
+    float posZ = getSurfaceZ();
+    float minl = posX - (getWidth()/2), maxl = posX + (getWidth()/2);
+    float minh = posY - (getHeight()/2), maxh = posY + (getHeight()/2);
+    float minp = posZ - (getWidth()/2), maxp = posZ + (getWidth()/2);
     glColor3f(0.5,0.5,0.5);
 
     //Drawing cube
@@ -60,10 +62,4 @@ void SquaredBuilding::generateBuilding(){
         glVertex3f(minl, minh, minp);
         glVertex3f(minl, maxh, minp);
     glEnd();
-}
-
-void SquaredBuilding::setSurfacePosition(float x, float y, float z){
-    posX = x;
-    posY = y;
-    posZ = z;
 }

--- a/CityProject/squaredbuilding.h
+++ b/CityProject/squaredbuilding.h
@@ -9,11 +9,9 @@
 class SquaredBuilding : public Building
 {
 private:
-    float posX, posY, posZ; //Position of bottom face of cube, top left point on city area (= surface)
 public:
     SquaredBuilding(int minh, int maxh, int minw, int maxw);
     void generateBuilding();
-    void setSurfacePosition(float x, float y, float z);
 };
 
 #endif // SQUAREDBUILDING_H

--- a/CityProject/testwindow.cpp
+++ b/CityProject/testwindow.cpp
@@ -36,7 +36,7 @@ void testWindow::resizeGL(int width, int height)
 void testWindow::paintGL()
 {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    build.generateBuilding();
+    build->generateBuilding();
     glFlush();
 }
 
@@ -53,6 +53,6 @@ void testWindow::loadTexture(QString textureName)
     glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
 }
 
-void testWindow::loadBuilding(House h){
+void testWindow::loadBuilding(Building * h){
     build = h;
 }

--- a/CityProject/testwindow.h
+++ b/CityProject/testwindow.h
@@ -15,11 +15,11 @@ class testWindow : public baseGLWidget
         void resizeGL(int width, int height);
         void paintGL();
         void loadTexture(QString texturename);
-        void loadBuilding(House h);
+        void loadBuilding(Building * h);
 
     private:
         GLuint texture[1]; //On charge une seule texture
-        House build;
+        Building * build;
 };
 
 #endif // TESTWINDOW_H


### PR DESCRIPTION
Descriptif de ce qui a été fait :

- Il n'est désormais plus possible d'ouvrir une fenêtre de test lorsqu'une autre est déjà ouverte (si cette action est réalisée, l'ancienne fenêtre est close au bénéfice de la nouvelle.
- Méthode loadBuilding, classe testWindow -> accepte désormais tous les bâtiments en général (paramètre attendu de type Building *)
- Méthode setSurfacePosition et attributs posX (à voir s'il faut conserver, cette coordonnée ne changera pas vu que tout les bâtiments seront sur une surface plate sur X), posY et posZ déplacés dans la classe Building (auparavant dans la classe SquaredBuilding), création d'accesseurs en conséquence.

Next : manipuler OpenGL, pour afficher le bâtiment en entier.