### PR TITLE
[05-12] Support caméra

### DIFF
--- a/CityProject/CityProject.pro
+++ b/CityProject/CityProject.pro
@@ -33,7 +33,9 @@ SOURCES += \
     squaredbuilding.cpp \
     circularbuilding.cpp \
     house.cpp \
-    tower.cpp
+    tower.cpp \
+    block.cpp \
+    surface_ville.cpp
 
 HEADERS += \
         mainwindow.h \
@@ -44,7 +46,8 @@ HEADERS += \
     circularbuilding.h \
     house.h \
     tower.h \
-    tower.h
+    block.h \
+    surface_ville.h
 
 FORMS += \
         mainwindow.ui

--- a/CityProject/baseglwidget.cpp
+++ b/CityProject/baseglwidget.cpp
@@ -1,11 +1,13 @@
 #include "baseglwidget.h"
+#include <sstream>
+#include <fstream>
 
 baseGLWidget::baseGLWidget(int framesPerSecond, QWidget *parent, char *name)
     : QGLWidget(parent)
 {
     setWindowTitle(QString::fromUtf8(name));
     if(framesPerSecond == 0)
-        t_Timer = NULL;
+        t_Timer = nullptr;
     else
     {
         int seconde = 1000; // 1 seconde = 1000 ms
@@ -15,6 +17,12 @@ baseGLWidget::baseGLWidget(int framesPerSecond, QWidget *parent, char *name)
         t_Timer->start( timerInterval );
     }
     fullscreen = false;
+    camXpos = 0.;
+    camZpos = -50.;
+    camXangle = 0;
+    camYangle = 45;
+    glGenVertexArrays(1, &VertexArrayID);
+    glBindVertexArray(VertexArrayID);
 }
 
 //Active le mode plein-écran si la fenêtre est en mode fenêtrée et vice-versa.
@@ -32,6 +40,59 @@ void baseGLWidget::toggleFullscreen()
     }
 }
 
+void baseGLWidget::translateCamera(int key, int valueModifier){
+    switch(key){
+        case Qt::Key_Z:
+            camZpos += valueModifier;
+            break;
+        case Qt::Key_S:
+            camZpos -= valueModifier;
+            break;
+        case Qt::Key_Q:
+            camXpos += valueModifier;
+            break;
+        case Qt::Key_D:
+            camXpos -= valueModifier;
+            break;
+    }
+    moveCamera();
+}
+
+void baseGLWidget::rotateCamera(int key, int valueModifier){
+    switch(key){
+        case Qt::Key_F:
+            camXangle -= valueModifier;
+            break;
+        case Qt::Key_R:
+            camXangle += valueModifier;
+            break;
+        case Qt::Key_A:
+            camYangle += valueModifier;
+            break;
+        case Qt::Key_E:
+            camYangle -= valueModifier;
+            break;
+    }
+    moveCamera();
+}
+
+void baseGLWidget::moveCamera(){
+    // On efface les pixels de l'image (color buffer) et le Z-Buffer (depth buffer).
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    // On initialise la matrice de vue avec la matrice identité.
+    glLoadIdentity();
+
+    // On applique une translation et une rotation à la scène pour simuler
+    // un déplacement de caméra.
+    glTranslatef(camXpos, 0, camZpos);
+    glRotatef(camXangle, 1, 0, 0);
+    glRotatef(camYangle, 0, 1, 0);
+
+    // On force OpenGL à afficher avant de passer à la suite.
+    glFlush();
+}
+
 void baseGLWidget::keyPressEvent(QKeyEvent *keyEvent)
 {
     switch(keyEvent->key())
@@ -41,6 +102,32 @@ void baseGLWidget::keyPressEvent(QKeyEvent *keyEvent)
             break;
         case Qt::Key_F1:
             toggleFullscreen();
+            break;
+        //Camera Translation
+        case Qt::Key_Z:
+            translateCamera(keyEvent->key(), 1);
+            break;
+        case Qt::Key_S:
+            translateCamera(keyEvent->key(), 1);
+            break;
+        case Qt::Key_Q:
+            translateCamera(keyEvent->key(), 1);
+            break;
+        case Qt::Key_D:
+            translateCamera(keyEvent->key(), 1);
+            break;
+        //Camera Rotation
+        case Qt::Key_A:
+            rotateCamera(keyEvent->key(), 1);
+            break;
+        case Qt::Key_E:
+            rotateCamera(keyEvent->key(), 1);
+            break;
+        case Qt::Key_R:
+            rotateCamera(keyEvent->key(), 1);
+            break;
+        case Qt::Key_F:
+            rotateCamera(keyEvent->key(), 1);
             break;
     }
 }
@@ -64,3 +151,92 @@ void baseGLWidget::timeOutSlot()
     //appel à paintGL
     updateGL();
 }
+
+GLuint baseGLWidget::loadShaders(const char * vertex_file_path, const char * fragment_file_path){
+
+    // Create the shaders
+    GLuint VertexShaderID = glCreateShader(GL_VERTEX_SHADER);
+    GLuint FragmentShaderID = glCreateShader(GL_FRAGMENT_SHADER);
+
+    // Read the Vertex Shader code from the file
+    std::string VertexShaderCode;
+    std::ifstream VertexShaderStream(vertex_file_path, std::ios::in);
+    if(VertexShaderStream.is_open()){
+        std::stringstream sstr;
+        sstr << VertexShaderStream.rdbuf();
+        VertexShaderCode = sstr.str();
+        VertexShaderStream.close();
+    }else{
+        printf("Impossible to open %s. Are you in the right directory ? Don't forget to read the FAQ !\n", vertex_file_path);
+        getchar();
+        return 0;
+    }
+
+    // Read the Fragment Shader code from the file
+    std::string FragmentShaderCode;
+    std::ifstream FragmentShaderStream(fragment_file_path, std::ios::in);
+    if(FragmentShaderStream.is_open()){
+        std::stringstream sstr;
+        sstr << FragmentShaderStream.rdbuf();
+        FragmentShaderCode = sstr.str();
+        FragmentShaderStream.close();
+    }
+
+    GLint Result = GL_FALSE;
+    int InfoLogLength;
+
+    // Compile Vertex Shader
+    printf("Compiling shader : %s\n", vertex_file_path);
+    char const * VertexSourcePointer = VertexShaderCode.c_str();
+    glShaderSource(VertexShaderID, 1, &VertexSourcePointer , nullptr);
+    glCompileShader(VertexShaderID);
+
+    // Check Vertex Shader
+    glGetShaderiv(VertexShaderID, GL_COMPILE_STATUS, &Result);
+    glGetShaderiv(VertexShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    if ( InfoLogLength > 0 ){
+        std::vector<char> VertexShaderErrorMessage(InfoLogLength+1);
+        glGetShaderInfoLog(VertexShaderID, InfoLogLength, nullptr, &VertexShaderErrorMessage[0]);
+        printf("%s\n", &VertexShaderErrorMessage[0]);
+    }
+
+    // Compile Fragment Shader
+    printf("Compiling shader : %s\n", fragment_file_path);
+    char const * FragmentSourcePointer = FragmentShaderCode.c_str();
+    glShaderSource(FragmentShaderID, 1, &FragmentSourcePointer , nullptr);
+    glCompileShader(FragmentShaderID);
+
+    // Check Fragment Shader
+    glGetShaderiv(FragmentShaderID, GL_COMPILE_STATUS, &Result);
+    glGetShaderiv(FragmentShaderID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    if ( InfoLogLength > 0 ){
+        std::vector<char> FragmentShaderErrorMessage(InfoLogLength+1);
+        glGetShaderInfoLog(FragmentShaderID, InfoLogLength, nullptr, &FragmentShaderErrorMessage[0]);
+        printf("%s\n", &FragmentShaderErrorMessage[0]);
+    }
+
+    // Link the program
+    printf("Linking program\n");
+    GLuint ProgramID = glCreateProgram();
+    glAttachShader(ProgramID, VertexShaderID);
+    glAttachShader(ProgramID, FragmentShaderID);
+    glLinkProgram(ProgramID);
+
+    // Check the program
+    glGetProgramiv(ProgramID, GL_LINK_STATUS, &Result);
+    glGetProgramiv(ProgramID, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    if ( InfoLogLength > 0 ){
+        std::vector<char> ProgramErrorMessage(InfoLogLength+1);
+        glGetProgramInfoLog(ProgramID, InfoLogLength, nullptr, &ProgramErrorMessage[0]);
+        printf("%s\n", &ProgramErrorMessage[0]);
+    }
+
+    glDetachShader(ProgramID, VertexShaderID);
+    glDetachShader(ProgramID, FragmentShaderID);
+
+    glDeleteShader(VertexShaderID);
+    glDeleteShader(FragmentShaderID);
+
+    return ProgramID;
+}
+

--- a/CityProject/baseglwidget.h
+++ b/CityProject/baseglwidget.h
@@ -1,9 +1,10 @@
 #ifndef BASEGLWIDGET_H
 #define BASEGLWIDGET_H
 
-
+#include <GL/glut.h>
 #include <QtOpenGL>
 #include <QGLWidget>
+#include <GLES3/gl3.h>
 
 class baseGLWidget : public QGLWidget
 {
@@ -16,6 +17,10 @@ public:
     virtual void keyPressEvent( QKeyEvent *keyEvent );
     void perspectiveGL( GLdouble fovY, GLdouble aspect, GLdouble zNear, GLdouble zFar );
     void toggleFullscreen();
+    void translateCamera(int key, int valueModifier);
+    void rotateCamera(int key, int valueModifier);
+    void moveCamera();
+    GLuint loadShaders(const char * vertex_file_path,const char * fragment_file_path);
 
 public slots:
     virtual void timeOutSlot();
@@ -23,6 +28,9 @@ public slots:
 private:
     QTimer *t_Timer;
     bool fullscreen;
+    float camXpos, camZpos; // For camera translation purpose
+    int camXangle, camYangle; // For camera rotation purpose
+    GLuint VertexArrayID; // Vertex Array Object
 
 };
 

--- a/CityProject/building.cpp
+++ b/CityProject/building.cpp
@@ -1,4 +1,5 @@
 #include "building.h"
+#include <GLES3/gl3.h>
 
 Building::Building(int minh, int maxh, int minw, int maxw)
 {
@@ -31,4 +32,21 @@ void Building::setSurfacePosition(float x, float y, float z){
     posX = x;
     posY = y;
     posZ = z;
+}
+
+void Building::drawBuilding(GLuint VertexBuffer, int bufferLength){
+    // 1st attribute buffer : vertices
+    glEnableVertexAttribArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, VertexBuffer);
+    glVertexAttribPointer(
+       0,                  // attribute 0. No particular reason for 0, but must match the layout in the shader.
+       3,                  // size
+       GL_FLOAT,           // type
+       GL_FALSE,           // normalized?
+       0,                  // stride
+       nullptr            // array buffer offset
+    );
+    // Draw the triangle !
+    glDrawArrays(GL_TRIANGLES, 0, bufferLength); // Starting from vertex 0; 3 vertices total -> 1 triangle
+    glDisableVertexAttribArray(0);
 }

--- a/CityProject/building.h
+++ b/CityProject/building.h
@@ -1,6 +1,7 @@
 #ifndef BUILDING_H
 #define BUILDING_H
 
+#include <GL/glut.h>
 #include <stdlib.h>
 #include <QDebug>
 
@@ -16,6 +17,7 @@ public :
     // On laisse aux classes filles le soin de déclarer cette fonction, car elle diffère selon
     // la forme générale du bâtiment (carrée, circulaire, ...)
     virtual void generateBuilding() = 0;
+    void drawBuilding(GLuint VertexBuffer, int bufferLength);
     Building(int minh, int maxh, int minw, int maxw);
     int getHeight();
     int getWidth();

--- a/CityProject/mainwindow.cpp
+++ b/CityProject/mainwindow.cpp
@@ -17,7 +17,8 @@ void MainWindow::on_actionBuildingWin_triggered()
 {
     if(twin != NULL) twin->close();
     twin = new testWindow();
-    Building * h = new Tower();
+    //Building * h = new Tower();
+    Building * h = new House();
     h->setSurfacePosition(0,0,0);
     twin->setAttribute(Qt::WA_DeleteOnClose);
     twin->loadBuilding(h);

--- a/CityProject/shaders/testfragment.fragmentshader
+++ b/CityProject/shaders/testfragment.fragmentshader
@@ -1,0 +1,7 @@
+#version 330 core
+
+out vec3 color;
+
+void main(){
+  color = vec3(0.5f, 0.5f, 0.5f);
+}

--- a/CityProject/shaders/testvertex.vertexshader
+++ b/CityProject/shaders/testvertex.vertexshader
@@ -1,0 +1,8 @@
+#version 330 core
+
+layout(location = 0) in vec3 vertexPosition_modelspace;
+
+void main(){
+	  gl_Position.xyz = vertexPosition_modelspace;
+	  gl_Position.w = 1.0;
+}

--- a/CityProject/squaredbuilding.cpp
+++ b/CityProject/squaredbuilding.cpp
@@ -1,4 +1,5 @@
 #include "squaredbuilding.h"
+#include <GLES3/gl3.h>
 
 SquaredBuilding::SquaredBuilding(int minh, int maxh, int minw, int maxw) : Building(minh, maxh, minw, maxw)
 {
@@ -63,3 +64,59 @@ void SquaredBuilding::generateBuilding(){
         glVertex3f(minl, maxh, minp);
     glEnd();
 }
+
+/*void SquaredBuilding::generateBuilding(){
+    float posX = getSurfaceX();
+    float posY = getSurfaceY();
+    float posZ = getSurfaceZ();
+    float minl = posX - (getWidth()/2), maxl = posX + (getWidth()/2);
+    float minh = posY - (getHeight()/2), maxh = posY + (getHeight()/2);
+    float minp = posZ - (getWidth()/2), maxp = posZ + (getWidth()/2);
+    static const GLfloat g_vertex_buffer_data[] = {
+        minl,minh,minp, // triangle 1 : begin
+        minl,minh, maxp,
+        minl, maxh, maxp, // triangle 1 : end
+        maxl, maxh,minp, // triangle 2 : begin
+        minl,minh,minp,
+        minl, maxh,minp, // triangle 2 : end
+        maxl,minh, maxp,
+        minl,minh,minp,
+        maxl,minh,minp,
+        maxl, maxh,minp,
+        maxl,minh,minp,
+        minl,minh,minp,
+        minl,minh,minp,
+        minl, maxh, maxp,
+        minl, maxh,minp,
+        maxl,minh, maxp,
+        minl,minh, maxp,
+        minl,minh,minp,
+        minl, maxh, maxp,
+        minl,minh, maxp,
+        maxl,minh, maxp,
+        maxl, maxh, maxp,
+        maxl,minh,minp,
+        maxl, maxh,minp,
+        maxl,minh,minp,
+        maxl, maxh, maxp,
+        maxl,minh, maxp,
+        maxl, maxh, maxp,
+        maxl, maxh,minp,
+        minl, maxh,minp,
+        maxl, maxh, maxp,
+        minl, maxh,minp,
+        minl, maxh, maxp,
+        maxl, maxh, maxp,
+        minl, maxh, maxp,
+        maxl,minh, maxp
+    };
+    // This will identify our vertex buffer
+    GLuint vertexbuffer;
+    // Generate 1 buffer, put the resulting identifier in vertexbuffer
+    glGenBuffers(1, &vertexbuffer);
+    // The following commands will talk about our 'vertexbuffer' buffer
+    glBindBuffer(GL_ARRAY_BUFFER, vertexbuffer);
+    // Give our vertices to OpenGL.
+    glBufferData(GL_ARRAY_BUFFER, sizeof(g_vertex_buffer_data), g_vertex_buffer_data, GL_STATIC_DRAW);
+    drawBuilding(vertexbuffer, 12*3);
+}*/

--- a/CityProject/testwindow.cpp
+++ b/CityProject/testwindow.cpp
@@ -9,14 +9,13 @@ testWindow::testWindow(QWidget *parent)
 //Initialisation d'openGL
 void testWindow::initializeGL()
 {
+    //GLuint programID = loadShaders("shaders/testvertex.vertexshader", "shaders/testfragment.fragmentshader");
     glShadeModel(GL_SMOOTH);
-    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-    glClearDepth(1.0f);
-    glEnable(GL_DEPTH_TEST);
-    glDepthFunc(GL_LEQUAL);
+    glClearColor(0.7f, 0.9f, 1.0f, 1.0f);
     glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
     loadTexture("texture/box.png");
     glEnable(GL_TEXTURE_2D);
+    //glUseProgram(programID);
 }
 
 //Fonction permettant de gérer le redimensionnement (changement résolution)


### PR DESCRIPTION
baseGLWidget :
- Ajout du support de la caméra, contrôles :
 - Translation :
  - Z : avancer
  - S : reculer
  - Q : déplacement vers la gauche
  - D : déplacement vers la droite
 - Rotation :
  - A : vers la gauche
  - E : vers la droite
  - R : vers le haut
  - F : vers le bas

 - Tentative de support des shaders (méthode loadShaders, provoque le crash du programme si utilisé, non utilisé pour l'instant)

- SquaredBuilding :
 -Tentative d'évolution de la fonction generateBuilding vers OpenGL 3 (ne fonctionne pas pour le moment, commenté)