### PR TITLE
[8-12] Avancement support shader

### DIFF
--- a/CityProject/baseglwidget.cpp
+++ b/CityProject/baseglwidget.cpp
@@ -1,4 +1,5 @@
 #include "baseglwidget.h"
+#include <iostream>
 #include <sstream>
 #include <fstream>
 
@@ -156,6 +157,9 @@ void baseGLWidget::timeOutSlot()
     updateGL();
 }
 
+//In order to easily access shaders directory in this project path, you need to disable Shadow
+//Build option (which is located at Projects, left sidebar) so build files are generated in
+//project directory.
 GLuint baseGLWidget::loadShaders(const char * vertex_file_path, const char * fragment_file_path){
 
     // Create the shaders
@@ -170,9 +174,9 @@ GLuint baseGLWidget::loadShaders(const char * vertex_file_path, const char * fra
         sstr << VertexShaderStream.rdbuf();
         VertexShaderCode = sstr.str();
         VertexShaderStream.close();
+        printf("Finished reading vertex shader file at %s\n", vertex_file_path);
     }else{
-        printf("Impossible to open %s. Are you in the right directory ? Don't forget to read the FAQ !\n", vertex_file_path);
-        getchar();
+        printf("Impossible to open %s. Are you in the right directory ?\n", vertex_file_path);
         return 0;
     }
 
@@ -184,6 +188,7 @@ GLuint baseGLWidget::loadShaders(const char * vertex_file_path, const char * fra
         sstr << FragmentShaderStream.rdbuf();
         FragmentShaderCode = sstr.str();
         FragmentShaderStream.close();
+        printf("Finished reading fragment shader file at %s\n", fragment_file_path);
     }
 
     GLint Result = GL_FALSE;
@@ -240,6 +245,8 @@ GLuint baseGLWidget::loadShaders(const char * vertex_file_path, const char * fra
 
     glDeleteShader(VertexShaderID);
     glDeleteShader(FragmentShaderID);
+
+    printf("Program successfully created, id : %d\n", int(ProgramID));
 
     return ProgramID;
 }

--- a/CityProject/baseglwidget.h
+++ b/CityProject/baseglwidget.h
@@ -10,7 +10,7 @@ class baseGLWidget : public QGLWidget
 {
     Q_OBJECT
 public:
-    explicit baseGLWidget(int framesPerSecond = 0, QWidget *parent = 0, char *name = 0);
+    explicit baseGLWidget(int framesPerSecond = 0, QWidget *parent = nullptr, char *name = nullptr);
     virtual void initializeGL() = 0;
     virtual void resizeGL(int width, int height) = 0;
     virtual void paintGL() = 0;

--- a/CityProject/building.cpp
+++ b/CityProject/building.cpp
@@ -34,15 +34,13 @@ void Building::setSurfacePosition(float x, float y, float z){
     posZ = z;
 }
 
-void Building::drawBuilding(GLuint VertexBuffer, const GLfloat vbdata, int bufferLength){
-    // Give our vertices to OpenGL.
-    glBufferData(GL_ARRAY_BUFFER, sizeof(vbdata), vbdata, GL_STATIC_DRAW);
+void Building::drawBuilding(GLuint VertexBuffer, int bufferLength){
     // 1st attribute buffer : vertices
     glEnableVertexAttribArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, VertexBuffer);
     glVertexAttribPointer(
        0,                  // attribute 0. No particular reason for 0, but must match the layout in the shader.
-       bufferLength,       // size
+       3,                   // size
        GL_FLOAT,           // type
        GL_FALSE,           // normalized?
        0,                  // stride

--- a/CityProject/building.h
+++ b/CityProject/building.h
@@ -17,8 +17,8 @@ private :
 public :
     // On laisse aux classes filles le soin de déclarer cette fonction, car elle diffère selon
     // la forme générale du bâtiment (carrée, circulaire, ...)
-    virtual const GLfloat generateBuilding(GLuint programID) = 0;
-    void drawBuilding(GLuint VertexBuffer, const GLfloat vbdata, int bufferLength);
+    virtual void generateBuilding(GLuint programID) = 0;
+    void drawBuilding(GLuint VertexBuffer, int bufferLength);
     Building(int minh, int maxh, int minw, int maxw);
     int getHeight();
     int getWidth();

--- a/CityProject/circularbuilding.cpp
+++ b/CityProject/circularbuilding.cpp
@@ -5,6 +5,6 @@ CircularBuilding::CircularBuilding(int minh, int maxh, int minw, int maxw) : Bui
 
 }
 
-const GLfloat CircularBuilding::generateBuilding(GLuint programID){
+void CircularBuilding::generateBuilding(GLuint programID){
 
 }

--- a/CityProject/circularbuilding.h
+++ b/CityProject/circularbuilding.h
@@ -10,7 +10,7 @@ class CircularBuilding : public Building
 private :
 
 public:
-    const GLfloat generateBuilding(GLuint programID);
+    void generateBuilding(GLuint programID);
     CircularBuilding(int minh, int maxh, int minw, int maxw);
 };
 

--- a/CityProject/shaders/testfragment.frag
+++ b/CityProject/shaders/testfragment.frag
@@ -1,5 +1,6 @@
-#version 330 core
+#version 300 es
 
+precision mediump float;
 out vec3 color;
 
 void main(){

--- a/CityProject/shaders/testvertex.vert
+++ b/CityProject/shaders/testvertex.vert
@@ -1,8 +1,8 @@
-#version 330 core
+#version 300 es
 
 layout(location = 0) in vec3 vertexPosition_modelspace;
 
 void main(){
-	  gl_Position.xyz = vertexPosition_modelspace;
-	  gl_Position.w = 1.0;
+	gl_Position.xyz = vertexPosition_modelspace;
+	gl_Position.w = 1.0;
 }

--- a/CityProject/squaredbuilding.cpp
+++ b/CityProject/squaredbuilding.cpp
@@ -65,7 +65,7 @@ SquaredBuilding::SquaredBuilding(int minh, int maxh, int minw, int maxw) : Build
     glEnd();
 }*/
 
-const GLfloat SquaredBuilding::generateBuilding(GLuint programID){
+void SquaredBuilding::generateBuilding(GLuint programID){
     float posX = getSurfaceX();
     float posY = getSurfaceY();
     float posZ = getSurfaceZ();
@@ -111,5 +111,6 @@ const GLfloat SquaredBuilding::generateBuilding(GLuint programID){
         minl, maxh, maxp,
         maxl,minh, maxp
     };
-    return g_vertex_buffer_data;
+    // Give our vertices to OpenGL.
+    glBufferData(GL_ARRAY_BUFFER, sizeof(g_vertex_buffer_data), g_vertex_buffer_data, GL_STATIC_DRAW);
 }

--- a/CityProject/squaredbuilding.h
+++ b/CityProject/squaredbuilding.h
@@ -11,7 +11,7 @@ class SquaredBuilding : public Building
 private:
 public:
     SquaredBuilding(int minh, int maxh, int minw, int maxw);
-    const GLfloat generateBuilding(GLuint programID);
+    void generateBuilding(GLuint programID);
 };
 
 #endif // SQUAREDBUILDING_H

--- a/CityProject/testwindow.cpp
+++ b/CityProject/testwindow.cpp
@@ -1,9 +1,11 @@
 #include "testwindow.h"
 #include "GL/glu.h"
+#include <iostream>
 
 testWindow::testWindow(QWidget *parent)
     : baseGLWidget(60, parent, "Building Test Window")
 {
+    programID = GLuint(-1);
 }
 
 //Initialisation d'openGL
@@ -15,6 +17,7 @@ void testWindow::initializeGL()
     glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
     loadTexture("texture/box.png");
     glEnable(GL_TEXTURE_2D);
+    build->generateBuilding(programID);
 }
 
 //Fonction permettant de gérer le redimensionnement (changement résolution)
@@ -25,7 +28,7 @@ void testWindow::resizeGL(int width, int height)
     glViewport(0, 0, width, height);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    perspectiveGL(45.0f, (GLfloat)width/(GLfloat)height, 0.1f, 100.0f);
+    perspectiveGL(45.0f, GLfloat(width)/GLfloat(height), 0.1f, 100.0f);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
 }
@@ -34,10 +37,9 @@ void testWindow::resizeGL(int width, int height)
 void testWindow::paintGL()
 {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    static const GLfloat vbufferdata = build->generateBuilding(programID);
     GLuint vb = getVertexBuffer();
     int bl = build->getBufferLength();
-    build->drawBuilding(vb, vbufferdata, bl);
+    build->drawBuilding(vb, bl);
     glFlush();
 }
 


### PR DESCRIPTION
L'application charge désormais correctement les shaders à l'ouverture de la fenêtre de test (shaders sous GLES 3.0).

Pb : le bâtiment ne s'affiche pas, les investigations continuent pour régler cela.