### PR TITLE
[02-01] Support Shaders (openGL 3.00 ES)

### DIFF
--- a/CityProject/CityProject.pro
+++ b/CityProject/CityProject.pro
@@ -26,25 +26,27 @@ LIBS += -Iglut -IGLU
 
 SOURCES += \
         main.cpp \
-        mainwindow.cpp \
-    baseglwidget.cpp \
-    testwindow.cpp \
+        #mainwindow.cpp \
+    #testwindow.cpp \
     building.cpp \
     squaredbuilding.cpp \
     circularbuilding.cpp \
     house.cpp \
-    tower.cpp
+    tower.cpp \
+    baseglwidget.cpp \
+    basegeometry.cpp
 
 HEADERS += \
-        mainwindow.h \
-    baseglwidget.h \
-    testwindow.h \
+        #mainwindow.h \
+    #testwindow.h \
     building.h \
     squaredbuilding.h \
     circularbuilding.h \
     house.h \
     tower.h \
-    tower.h
+    tower.h \
+    baseglwidget.h \
+    basegeometry.h
 
 FORMS += \
         mainwindow.ui

--- a/CityProject/basegeometry.cpp
+++ b/CityProject/basegeometry.cpp
@@ -1,0 +1,127 @@
+#include "basegeometry.h"
+
+#include <QVector2D>
+#include <QVector3D>
+
+struct VertexData
+{
+    QVector3D position;
+    QVector2D texCoord;
+};
+
+baseGeometry::baseGeometry(QString vsp, QString fsp, QVector3D center, QVector3D scale)
+    : indexBuf(QOpenGLBuffer::IndexBuffer),
+      vertexShaderPath(vsp),
+      fragShaderPath(fsp),
+      centerModel(center),
+      scaleModel(scale)
+{
+    initializeOpenGLFunctions();
+
+    // Generate 2 VBOs
+    arrayBuf.create();
+    indexBuf.create();
+
+    // Initializes cube geometry and transfers it to VBOs
+    initGeometry();
+}
+
+baseGeometry::~baseGeometry()
+{
+    arrayBuf.destroy();
+    indexBuf.destroy();
+}
+
+void baseGeometry::initGeometry()
+{
+    // For cube we would need only 8 vertices but we have to
+    // duplicate vertex for each face because texture coordinate
+    // is different.
+    VertexData vertices[] = {
+        // Vertex data for face 0
+        {QVector3D(-1.0f, -1.0f,  1.0f), QVector2D(0.0f, 0.0f)},  // v0
+        {QVector3D( 1.0f, -1.0f,  1.0f), QVector2D(0.33f, 0.0f)}, // v1
+        {QVector3D(-1.0f,  1.0f,  1.0f), QVector2D(0.0f, 0.5f)},  // v2
+        {QVector3D( 1.0f,  1.0f,  1.0f), QVector2D(0.33f, 0.5f)}, // v3
+
+        // Vertex data for face 1
+        {QVector3D( 1.0f, -1.0f,  1.0f), QVector2D( 0.0f, 0.5f)}, // v4
+        {QVector3D( 1.0f, -1.0f, -1.0f), QVector2D(0.33f, 0.5f)}, // v5
+        {QVector3D( 1.0f,  1.0f,  1.0f), QVector2D(0.0f, 1.0f)},  // v6
+        {QVector3D( 1.0f,  1.0f, -1.0f), QVector2D(0.33f, 1.0f)}, // v7
+
+        // Vertex data for face 2
+        {QVector3D( 1.0f, -1.0f, -1.0f), QVector2D(0.66f, 0.5f)}, // v8
+        {QVector3D(-1.0f, -1.0f, -1.0f), QVector2D(1.0f, 0.5f)},  // v9
+        {QVector3D( 1.0f,  1.0f, -1.0f), QVector2D(0.66f, 1.0f)}, // v10
+        {QVector3D(-1.0f,  1.0f, -1.0f), QVector2D(1.0f, 1.0f)},  // v11
+
+        // Vertex data for face 3
+        {QVector3D(-1.0f, -1.0f, -1.0f), QVector2D(0.66f, 0.0f)}, // v12
+        {QVector3D(-1.0f, -1.0f,  1.0f), QVector2D(1.0f, 0.0f)},  // v13
+        {QVector3D(-1.0f,  1.0f, -1.0f), QVector2D(0.66f, 0.5f)}, // v14
+        {QVector3D(-1.0f,  1.0f,  1.0f), QVector2D(1.0f, 0.5f)},  // v15
+
+        // Vertex data for face 4
+        {QVector3D(-1.0f, -1.0f, -1.0f), QVector2D(0.33f, 0.0f)}, // v16
+        {QVector3D( 1.0f, -1.0f, -1.0f), QVector2D(0.66f, 0.0f)}, // v17
+        {QVector3D(-1.0f, -1.0f,  1.0f), QVector2D(0.33f, 0.5f)}, // v18
+        {QVector3D( 1.0f, -1.0f,  1.0f), QVector2D(0.66f, 0.5f)}, // v19
+
+        // Vertex data for face 5
+        {QVector3D(-1.0f,  1.0f,  1.0f), QVector2D(0.33f, 0.5f)}, // v20
+        {QVector3D( 1.0f,  1.0f,  1.0f), QVector2D(0.66f, 0.5f)}, // v21
+        {QVector3D(-1.0f,  1.0f, -1.0f), QVector2D(0.33f, 1.0f)}, // v22
+        {QVector3D( 1.0f,  1.0f, -1.0f), QVector2D(0.66f, 1.0f)}  // v23
+    };
+
+    // Indices for drawing cube faces using triangle strips.
+    // Triangle strips can be connected by duplicating indices
+    // between the strips. If connecting strips have opposite
+    // vertex order then last index of the first strip and first
+    // index of the second strip needs to be duplicated. If
+    // connecting strips have same vertex order then only last
+    // index of the first strip needs to be duplicated.
+    GLushort indices[] = {
+         0,  1,  2,  3,  3,     // Face 0 - triangle strip ( v0,  v1,  v2,  v3)
+         4,  4,  5,  6,  7,  7, // Face 1 - triangle strip ( v4,  v5,  v6,  v7)
+         8,  8,  9, 10, 11, 11, // Face 2 - triangle strip ( v8,  v9, v10, v11)
+        12, 12, 13, 14, 15, 15, // Face 3 - triangle strip (v12, v13, v14, v15)
+        16, 16, 17, 18, 19, 19, // Face 4 - triangle strip (v16, v17, v18, v19)
+        20, 20, 21, 22, 23      // Face 5 - triangle strip (v20, v21, v22, v23)
+    };
+
+    // Transfer vertex data to VBO 0
+    arrayBuf.bind();
+    arrayBuf.allocate(vertices, 24 * sizeof(VertexData));
+
+    // Transfer index data to VBO 1
+    indexBuf.bind();
+    indexBuf.allocate(indices, 34 * sizeof(GLushort));
+}
+
+void baseGeometry::drawGeometry(QOpenGLShaderProgram *program)
+{
+    // Tell OpenGL which VBOs to use
+    arrayBuf.bind();
+    indexBuf.bind();
+
+    // Offset for position
+    quintptr offset = 0;
+
+    // Tell OpenGL programmable pipeline how to locate vertex position data
+    int vertexLocation = program->attributeLocation("a_position");
+    program->enableAttributeArray(vertexLocation);
+    program->setAttributeBuffer(vertexLocation, GL_FLOAT, offset, 3, sizeof(VertexData));
+
+    // Offset for texture coordinate
+    //offset += sizeof(QVector3D);
+
+    // Tell OpenGL programmable pipeline how to locate vertex texture coordinate data
+    /*int texcoordLocation = program->attributeLocation("a_texcoord");
+    program->enableAttributeArray(texcoordLocation);
+    program->setAttributeBuffer(texcoordLocation, GL_FLOAT, offset, 2, sizeof(VertexData));*/
+
+    // Draw cube geometry using indices from VBO 1
+    glDrawElements(GL_TRIANGLE_STRIP, 34, GL_UNSIGNED_SHORT, 0);
+}

--- a/CityProject/basegeometry.h
+++ b/CityProject/basegeometry.h
@@ -1,0 +1,34 @@
+#ifndef BASEGEOMETRY_H
+#define BASEGEOMETRY_H
+
+#include <QOpenGLFunctions>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLBuffer>
+
+class baseGeometry : protected QOpenGLFunctions
+{
+public:
+    baseGeometry(QString vsp, QString fsp, QVector3D center, QVector3D scale);
+    virtual ~baseGeometry();
+
+    void drawGeometry(QOpenGLShaderProgram *program);
+
+    QString getVertexShaderPath(){ return vertexShaderPath; }
+    QString getFragShaderPath(){ return fragShaderPath; }
+    QVector3D getCenterModel(){ return centerModel; }
+    QVector3D getScaleModel(){ return scaleModel; }
+
+protected:
+    void initGeometry();
+
+    QString vertexShaderPath;
+    QString fragShaderPath;
+
+    QOpenGLBuffer arrayBuf;
+    QOpenGLBuffer indexBuf;
+
+    QVector3D centerModel;
+    QVector3D scaleModel;
+};
+
+#endif // BASEGEOMETRY_H

--- a/CityProject/baseglwidget.h
+++ b/CityProject/baseglwidget.h
@@ -1,38 +1,37 @@
 #ifndef BASEGLWIDGET_H
 #define BASEGLWIDGET_H
 
-#include <GL/glut.h>
-#include <QtOpenGL>
-#include <QGLWidget>
-#include <GLES3/gl3.h>
+#include "basegeometry.h"
 
-class baseGLWidget : public QGLWidget
+#include <QOpenGLWidget>
+#include <QOpenGLFunctions>
+#include <QOpenGLBuffer>
+#include <QOpenGLShaderProgram>
+#include <QKeyEvent>
+#include <QBasicTimer>
+
+class baseGLWidget : public QOpenGLWidget, protected QOpenGLFunctions
 {
-    Q_OBJECT
+ Q_OBJECT
 public:
-    explicit baseGLWidget(int framesPerSecond = 0, QWidget *parent = nullptr, char *name = nullptr);
-    virtual void initializeGL() = 0;
-    virtual void resizeGL(int width, int height) = 0;
-    virtual void paintGL() = 0;
-    virtual void keyPressEvent( QKeyEvent *keyEvent );
-    void perspectiveGL( GLdouble fovY, GLdouble aspect, GLdouble zNear, GLdouble zFar );
-    void toggleFullscreen();
-    void translateCamera(int key, int valueModifier);
-    void rotateCamera(int key, int valueModifier);
-    void moveCamera();
-    GLuint loadShaders(const char * vertex_file_path,const char * fragment_file_path);
-    GLuint getVertexBuffer(){ return VertexBuffer; }
+    baseGLWidget(QWidget* parent = nullptr );
 
-public slots:
-    virtual void timeOutSlot();
+protected:
+    virtual void initializeGL();
+    virtual void resizeGL( int w, int h );
+    virtual void paintGL();
+    virtual void keyPressEvent( QKeyEvent* e );
+    void timerEvent(QTimerEvent* e);
 
 private:
-    QTimer *t_Timer;
-    bool fullscreen;
-    float camXpos, camZpos; // For camera translation purpose
-    int camXangle, camYangle; // For camera rotation purpose
-    GLuint VertexArrayID; // Vertex Array Object
-    GLuint VertexBuffer;
+    bool prepareShaderProgram( const QString& vertexShaderPath, const QString& fragmentShaderPath );
+
+    QOpenGLShaderProgram shaderProgram_;
+    baseGeometry* geometries_;
+    QBasicTimer timer_;
+
+    QVector3D cameraPos_;
+    QMatrix4x4 projection_;
 };
 
 #endif // BASEGLWIDGET_H

--- a/CityProject/main.cpp
+++ b/CityProject/main.cpp
@@ -1,10 +1,18 @@
-#include "mainwindow.h"
+#include <QApplication>
+
+#include "baseglwidget.h"
+
+//#include "mainwindow.h"
 
 int main(int argc, char *argv[])
 {
-    srand(time(NULL));
+    srand(time(nullptr));
     QApplication a(argc, argv);
-    MainWindow mWin;
-    mWin.show();
+    /*MainWindow mWin;
+    mWin.show();*/
+
+    baseGLWidget w;
+    w.show();
+
     return a.exec();
 }


### PR DESCRIPTION
J'AI ENFIN REUSSI A FAIRE FONCTIONNER CES SHADERS !!! (Fallait que je mette ça en majuscules, ça fait du bien :3)

_ BASEGLWIDGET _

- La classe baseGLWidget a été entièrement réécrite, pour utiliser les bibliothèques OpenGL proposées par Qt (QOpenGLShaderProgram, ... etc.) et des classes Qt (QVector3D, QMatrix4x4) : pour l'instant, on ne peut afficher qu'un objet dans la fenêtre (geometries_), et un seul programme shader (shaderProgram_).

- baseGLWidget : il est possible d'effectuer des translations à la caméra. Contrôles : Z (Avancer), S (Reculer), Q (Gauche), D (Droite), Flèche Haut (Haut), Flèche Bas (Bas)
La caméra pointe sur le centre du seul objet affiché : il est prévu de modifier cela pour que la caméra pointe sur le centre du premier des objets affichés (ainsi, pour la vue ville, ce sera le centre de la surface de la ville, qui sera donc le premier objet à générer.)

_ BASEGEOMETRY _

- Nouvelle classe, baseGeometry : il s'agira de la classe mère des objets 3D que nous allons générer pour affichage.
 - Nécessite le chemin vers un fichier vertex shader, le chemin vers un fichier fragment shader (il sera peut-être nécessaire de modifier les chemins dans le code, il faut que ça pointe vers les fichiers du dossier shaders), les coordonnées du centre de l'objet et les dimensions de l'objet (sous forme de vecteur : x -> largeur, y -> hauteur, z -> profondeur)
 - De base, crée un cube.

_ NOTES _

- En exécutant le programme, vous devriez voir une fenêtre avec un fond bleu et un cube de couleur rouge : c'est provisoire bien entendu.

A faire, pour mes prochaines sessions :

- baseGLWidget : Permettre l'affichage de plusieurs objets et la gestion de plusieurs programmes shaders (afin d'avoir un programme shader pour les bâtiments, un autre pour la surface de la ville, un autre pour les routes ... etc)
- Réécrire les classes de forme de bâtiments (SquaredBuilding, CircularBuilding, ... etc) pour qu'elles soient classes filles de baseGeometry, surcharger les méthodes initGeometry (et drawGeometry ?)
- Réécrire les classes de fenêtres (MainWindow, testWindow) pour intégrer les modifications apportées.
- Inclure les rotations de la caméra (limitées, on ne veut pas voir sous la surface de la ville)

Une fois tout cela fait, on pourra enfin bosser sur l'affichage de ville aléatoire.