### PR TITLE
[06-01] Option Surface Personnalisée

### DIFF
--- a/CityProject/CityProject.pro
+++ b/CityProject/CityProject.pro
@@ -34,7 +34,12 @@ SOURCES += \
     tower.cpp \
     baseglwidget.cpp \
     basegeometry.cpp \
-    conebuilding.cpp
+    conebuilding.cpp \
+    district.cpp \
+    downtown.cpp \
+    periphery.cpp \
+    activityarea.cpp \
+    gridsurfacedialog.cpp
 
 HEADERS += \
         mainwindow.h \
@@ -45,7 +50,13 @@ HEADERS += \
     tower.h \
     baseglwidget.h \
     basegeometry.h \
-    conebuilding.h
+    conebuilding.h \
+    district.h \
+    downtown.h \
+    periphery.h \
+    activityarea.h \
+    gridsurfacedialog.h
 
 FORMS += \
-        mainwindow.ui
+        mainwindow.ui \
+    gridsurfacedialog.ui

--- a/CityProject/activityarea.cpp
+++ b/CityProject/activityarea.cpp
@@ -1,0 +1,6 @@
+#include "activityarea.h"
+
+ActivityArea::ActivityArea()
+{
+
+}

--- a/CityProject/activityarea.h
+++ b/CityProject/activityarea.h
@@ -1,0 +1,12 @@
+#ifndef ACTIVITYAREA_H
+#define ACTIVITYAREA_H
+
+#include "district.h"
+
+class ActivityArea : public District
+{
+public:
+    ActivityArea();
+};
+
+#endif // ACTIVITYAREA_H

--- a/CityProject/baseglwidget.cpp
+++ b/CityProject/baseglwidget.cpp
@@ -32,7 +32,8 @@ void baseGLWidget::initializeGL()
     }
 
     glEnable(GL_DEPTH_TEST);
-    glEnable(GL_CULL_FACE);
+    //Enabling face culling causes missing triangles on meshes.
+    //glEnable(GL_CULL_FACE);
 
     timer_.start(12, this);
 }

--- a/CityProject/district.cpp
+++ b/CityProject/district.cpp
@@ -1,0 +1,6 @@
+#include "district.h"
+
+District::District()
+{
+
+}

--- a/CityProject/district.h
+++ b/CityProject/district.h
@@ -1,0 +1,11 @@
+#ifndef DISTRICT_H
+#define DISTRICT_H
+
+
+class District
+{
+public:
+    District();
+};
+
+#endif // DISTRICT_H

--- a/CityProject/downtown.cpp
+++ b/CityProject/downtown.cpp
@@ -1,0 +1,6 @@
+#include "downtown.h"
+
+Downtown::Downtown()
+{
+
+}

--- a/CityProject/downtown.h
+++ b/CityProject/downtown.h
@@ -1,0 +1,12 @@
+#ifndef DOWNTOWN_H
+#define DOWNTOWN_H
+
+#include "district.h"
+
+class Downtown : public District
+{
+public:
+    Downtown();
+};
+
+#endif // DOWNTOWN_H

--- a/CityProject/gridsurfacedialog.cpp
+++ b/CityProject/gridsurfacedialog.cpp
@@ -1,0 +1,119 @@
+#include "gridsurfacedialog.h"
+#include "ui_gridsurfacedialog.h"
+
+#include <QGraphicsView>
+#include <QScrollBar>
+#include <iostream>
+
+GridSurfaceDialog::GridSurfaceDialog(int cityWidth, int cityDepth, int nbGridCol, int nbGridRow, QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::GridSurfaceDialog),
+    dimCubeSelection_(0),
+    cubeDim_(10)
+{
+    //One rectangle covers rectSurfaceWidth_ * rectSurfaceDepth_ area on city surface.
+    rectSurfaceWidth_ = float(cityWidth) / float(nbGridCol);
+    rectSurfaceDepth_ = float(cityDepth) / float(nbGridRow);
+
+    QString rsw = QString::number(rectSurfaceWidth_);
+    QString rsd = QString::number(rectSurfaceDepth_);
+
+    ui->setupUi(this);
+
+    scene = new QGraphicsScene(this);
+    ui->graphicsView->setScene(scene);
+    ui->gridInfo->setText("Info : One rectangle in grid = one area in city's surface area, dimensions : " + rsw + " * " + rsd);
+
+    // Add event listener to the graphics view, so we can detect mouse click.
+    ui->graphicsView->viewport()->installEventFilter(this);
+
+    currBrush_ = QBrush(Qt::green);
+    QPen blackPen(Qt::black);
+    blackPen.setWidth(0);
+
+    // Init surface grid with 100 % Periphery.
+    for (int i = 0; i < nbGridRow; i++){
+        std::vector<QGraphicsRectItem *> gridrow;
+        for(int j = 0; j < nbGridCol ; j++){
+            QGraphicsRectItem * rec = scene->addRect(i * cubeDim_, j * cubeDim_, cubeDim_, cubeDim_, blackPen);
+            rec->setBrush(currBrush_);
+            gridrow.push_back(rec);
+        }
+        grid_.push_back(gridrow);
+    }
+}
+
+GridSurfaceDialog::~GridSurfaceDialog()
+{
+    delete ui;
+}
+
+// Event listener for the graphic view.
+bool GridSurfaceDialog::eventFilter(QObject *watched, QEvent *event){
+    if(event->type() == QEvent::MouseButtonPress){
+        QMouseEvent* e = static_cast<QMouseEvent*>(event);
+        if(e->buttons() == Qt::LeftButton){
+            int addx = ui->graphicsView->horizontalScrollBar()->value();
+            int addy = ui->graphicsView->verticalScrollBar()->value();
+            modifyGridColors(e->x() + addx, e->y() + addy);
+        }else{
+            return QObject::eventFilter(watched, event);
+        }
+        return true;
+    }else{
+        return QObject::eventFilter(watched, event);
+    }
+}
+
+void GridSurfaceDialog::modifyGridColors(int x, int y){
+    // Get indexes of clicked square.
+    int row = y / cubeDim_;
+    int col = x / cubeDim_;
+
+    // Compute indexes of grid area to color (Centered at clicked square,
+    // sides length for each : 1 + (2 * dimCubeSelection) squares).
+    int rowmin = row - dimCubeSelection_;
+    rowmin = rowmin < 0 ? 0 : rowmin;
+    int rowmax = row + dimCubeSelection_;
+    rowmax = rowmax >= grid_.at(0).size() ? grid_.at(0).size() - 1 : rowmax;
+    int colmin = col - dimCubeSelection_;
+    colmin = colmin < 0 ? 0 : colmin;
+    int colmax = col + dimCubeSelection_;
+    colmax = colmax >= grid_.size() ? grid_.size() - 1 : colmax;
+
+    // Change grid area selected to current color, if needed.
+    for(int c = colmin; c <= colmax; c++){
+        for(int r = rowmin; r <= rowmax; r++){
+            QBrush b = grid_.at(c).at(r)->brush();
+            if(b != currBrush_) grid_.at(c).at(r)->setBrush(currBrush_);
+        }
+    }
+}
+
+// Change color based on district type we want to represent.
+void GridSurfaceDialog::on_comboBox_currentIndexChanged(int index)
+{
+    switch(index){
+        case 0: // Periphery
+            currBrush_ = QBrush(Qt::green);
+            break;
+        case 1: // Downtown
+            currBrush_ = QBrush(Qt::red);
+            break;
+        case 2: // Activity Area
+            currBrush_ = QBrush(Qt::gray);
+            break;
+    }
+}
+
+// Change square selection's side length.
+void GridSurfaceDialog::on_spinBox_valueChanged(int arg1)
+{
+    dimCubeSelection_ = arg1;
+}
+
+// Send surface grid to MainWindow.
+void GridSurfaceDialog::on_buttonBox_accepted()
+{
+    emit sendSurfaceData(grid_);
+}

--- a/CityProject/gridsurfacedialog.h
+++ b/CityProject/gridsurfacedialog.h
@@ -1,0 +1,42 @@
+#ifndef GRIDSURFACEDIALOG_H
+#define GRIDSURFACEDIALOG_H
+
+#include <QDialog>
+#include <QtGui>
+#include <QtCore>
+#include <QGraphicsScene>
+#include <QGraphicsRectItem>
+
+namespace Ui {
+class GridSurfaceDialog;
+}
+
+class GridSurfaceDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit GridSurfaceDialog(int cityWidth, int cityDepth, int nbGridRow, int nbGridCol, QWidget *parent = nullptr);
+    ~GridSurfaceDialog();
+
+private:
+    bool eventFilter(QObject *watched, QEvent *event);
+    void modifyGridColors(int x, int y);
+    Ui::GridSurfaceDialog *ui;
+    QGraphicsScene *scene;
+    std::vector<std::vector<QGraphicsRectItem *>> grid_;
+    QBrush currBrush_;
+    float rectSurfaceWidth_, rectSurfaceDepth_;
+    int dimCubeSelection_;
+    int cubeDim_;
+
+private slots:
+    void on_comboBox_currentIndexChanged(int index);
+    void on_spinBox_valueChanged(int arg1);
+    void on_buttonBox_accepted();
+
+signals:
+    void sendSurfaceData(std::vector<std::vector<QGraphicsRectItem *>>);
+};
+
+#endif // GRIDSURFACEDIALOG_H

--- a/CityProject/gridsurfacedialog.ui
+++ b/CityProject/gridsurfacedialog.ui
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GridSurfaceDialog</class>
+ <widget class="QDialog" name="GridSurfaceDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1024</width>
+    <height>768</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>1024</width>
+    <height>768</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>670</x>
+     <y>720</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QGraphicsView" name="graphicsView">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>20</y>
+     <width>751</width>
+     <height>671</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="gridInfo">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>700</y>
+     <width>751</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>TextLabel</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="comboBox">
+   <property name="geometry">
+    <rect>
+     <x>900</x>
+     <y>330</y>
+     <width>121</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <item>
+    <property name="text">
+     <string>Periphery</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Downtown</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Activity Area</string>
+    </property>
+   </item>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>780</x>
+     <y>280</y>
+     <width>231</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Drawing Settings</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>770</x>
+     <y>380</y>
+     <width>161</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Size of Cube Selection :</string>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="spinBox">
+   <property name="geometry">
+    <rect>
+     <x>940</x>
+     <y>380</y>
+     <width>81</width>
+     <height>26</height>
+    </rect>
+   </property>
+   <property name="minimum">
+    <number>0</number>
+   </property>
+   <property name="maximum">
+    <number>100</number>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_3">
+   <property name="geometry">
+    <rect>
+     <x>770</x>
+     <y>330</y>
+     <width>131</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>District Selection :</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>GridSurfaceDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>GridSurfaceDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/CityProject/mainwindow.cpp
+++ b/CityProject/mainwindow.cpp
@@ -1,13 +1,21 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+
 #include "house.h"
 #include "tower.h"
+#include "periphery.h"
+#include "downtown.h"
+#include "activityarea.h"
+
+#include <iostream>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+    twin = nullptr;
+    gswin = nullptr;
 }
 
 MainWindow::~MainWindow()
@@ -41,4 +49,54 @@ void MainWindow::on_actionBuildingWin_triggered()
 
     twin = new baseGLWidget(geos_);
     twin->show();
+}
+
+void MainWindow::on_comboBox_activated(int index)
+{
+    switch(index){
+        case 0: // "Concentrique" option
+            std::cout << "Concentrique : not implemented yet." << std::endl;
+            break;
+        case 1: // "100 % Centre-ville" option
+            std::cout << "100 % Centre-ville : not implemented yet." << std::endl;
+            break;
+        case 2: // "100 % Périphérie" option
+            std::cout << "100 % Périphérie : not implemented yet." << std::endl;
+            break;
+        case 3: // "100 % ZA" option
+            std::cout << "100 % ZA : not implemented yet." << std::endl;
+            break;
+        case 4: // "Personnalisée..." option
+            if(gswin != nullptr) gswin->close();
+            gswin = new GridSurfaceDialog(1000, 1000, 75, 75);
+            connect(gswin, &GridSurfaceDialog::sendSurfaceData,
+                    this, &MainWindow::on_GridSurfaceDialog_sendSurfaceData);
+            gswin->show();
+            break;
+    }
+}
+
+void MainWindow::on_GridSurfaceDialog_sendSurfaceData(std::vector<std::vector<QGraphicsRectItem *>> grid){
+    //Don't forget to erase old surfaceGrid_ if there's an existing one.
+    surfaceGrid_.erase(surfaceGrid_.begin(), surfaceGrid_.end());
+
+    for(ulong i = 0; i < grid.size(); i++){
+        std::vector<District *> col;
+        for(ulong j = 0; j < grid.at(i).size(); j++){
+            QGraphicsRectItem * rec = grid.at(i).at(j);
+            QBrush rb = rec->brush();
+            if(rb.color() == Qt::green){
+                col.push_back(new Periphery());
+            }else{
+                if(rb.color() == Qt::red){
+                    col.push_back(new Downtown());
+                }else{
+                    col.push_back(new ActivityArea());
+                }
+            }
+        }
+        surfaceGrid_.push_back(col);
+    }
+
+    std::cout << "Surface grid loaded successfully." << std::endl;
 }

--- a/CityProject/mainwindow.h
+++ b/CityProject/mainwindow.h
@@ -5,6 +5,8 @@
 #include <QApplication>
 
 #include "baseglwidget.h"
+#include "district.h"
+#include "gridsurfacedialog.h"
 
 namespace Ui {
 class MainWindow;
@@ -21,9 +23,16 @@ public:
 private slots:
     void on_actionBuildingWin_triggered();
 
+    void on_comboBox_activated(int index);
+
+public slots:
+    void on_GridSurfaceDialog_sendSurfaceData(std::vector<std::vector<QGraphicsRectItem *>>);
+
 private:
     Ui::MainWindow *ui;
     baseGLWidget * twin;
+    GridSurfaceDialog * gswin;
+    std::vector<std::vector<District *>> surfaceGrid_;
 };
 
 #endif // MAINWINDOW_H

--- a/CityProject/mainwindow.ui
+++ b/CityProject/mainwindow.ui
@@ -13,7 +13,69 @@
   <property name="windowTitle">
    <string>MyCity Project</string>
   </property>
-  <widget class="QWidget" name="centralWidget"/>
+  <widget class="QWidget" name="centralWidget">
+   <widget class="QComboBox" name="comboBox">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>160</y>
+      <width>181</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <item>
+     <property name="text">
+      <string>Concentrique</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>100 % Centre-ville</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>100 % Périphérie</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>100 % Zone d'activités</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Personnalisée ...</string>
+     </property>
+    </item>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>160</y>
+      <width>131</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Surface de la ville :</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="pushButton">
+    <property name="geometry">
+     <rect>
+      <x>140</x>
+      <y>200</y>
+      <width>111</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Générer ville !</string>
+    </property>
+   </widget>
+  </widget>
   <widget class="QToolBar" name="mainToolBar">
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>

--- a/CityProject/periphery.cpp
+++ b/CityProject/periphery.cpp
@@ -1,0 +1,6 @@
+#include "periphery.h"
+
+Periphery::Periphery()
+{
+
+}

--- a/CityProject/periphery.h
+++ b/CityProject/periphery.h
@@ -1,0 +1,12 @@
+#ifndef PERIPHERY_H
+#define PERIPHERY_H
+
+#include "district.h"
+
+class Periphery : public District
+{
+public:
+    Periphery();
+};
+
+#endif // PERIPHERY_H


### PR DESCRIPTION
Sur la fenêtre principale, ajout d'une liste permettant de sélectionner le type de surface que l'on souhaite avoir.

Pour l'instant, seul l'option "Personnalisée ..." a été implémentée : lorsque l'utilisateur sélectionne cette option, une nouvelle fenêtre s'affiche (classe GridSurfaceDialog).

A l'intérieur de celle-ci, une grille est affichée, représentant la surface de la ville : une case de cette grille équivaut à une certaine taille de zone de la surface de la ville. Elle diffère selon les dimensions de la surface de la ville et le nombre de lignes et colonnes que l'on veut avoir pour notre grille.

Il est possible de colorer cette grille, à 100 % Périphérie par défaut, en sélectionnant le type de quartier que l'on souhaite représenter (Centre-ville, périphérie ...), puis en modifiant si besoin la taille de longueur de côté de zone à sélectionner et colorer sur la grille.

Une fois satisfait du résultat, l'utilisateur pourra cliquer sur le bouton OK : la grille sera transmise à la fenêtre principale, et interprétée : pour chaque case de la grille envoyée :

- Si la couleur est verte, la zone correspondante sera une périphérie,
- Si la couleur est rouge, la zone correspondante sera un centre-ville,
- Si la couleur est grise, il s'agit d'une zone d'activités.

_ DIVERS _

- Correction du problème des faces manquantes sur les tours coniques (ne pas activer le culling de face a été la solution)
- Ajout des classes suivantes : District, Periphery, Downtown et ActivityArea : pour l'instant, ces classes ne font rien, si ce n'est que la classe District est mère de toutes les autres.

_ TO-DO _

- Donner un sens aux classes quartiers (Probas d'apparition de certains types de bâtiments, ou de rien du tout, diffère selon le type de quartier dans lequel on est)
- Afficher la fenêtre ville avec les infos récoltées (si grille surface existe, afficher surface et apparition randomisée de bâtiments dessus)
- Implémenter les autres options de type de surface.