### PR TITLE
[09-01, matin] Interface, autres options surface

### DIFF
--- a/CityProject/CityProject.pro
+++ b/CityProject/CityProject.pro
@@ -39,7 +39,8 @@ SOURCES += \
     downtown.cpp \
     periphery.cpp \
     activityarea.cpp \
-    gridsurfacedialog.cpp
+    gridsurfacedialog.cpp \
+    factory.cpp
 
 HEADERS += \
         mainwindow.h \
@@ -55,7 +56,8 @@ HEADERS += \
     downtown.h \
     periphery.h \
     activityarea.h \
-    gridsurfacedialog.h
+    gridsurfacedialog.h \
+    factory.h
 
 FORMS += \
         mainwindow.ui \

--- a/CityProject/activityarea.cpp
+++ b/CityProject/activityarea.cpp
@@ -1,6 +1,7 @@
 #include "activityarea.h"
 
-ActivityArea::ActivityArea()
+ActivityArea::ActivityArea(int c, int r, float rsw, float rsd) :
+    District (c, r, rsw, rsd)
 {
 
 }

--- a/CityProject/activityarea.h
+++ b/CityProject/activityarea.h
@@ -6,7 +6,7 @@
 class ActivityArea : public District
 {
 public:
-    ActivityArea();
+    ActivityArea(int c, int r, float rsw, float rsd);
 };
 
 #endif // ACTIVITYAREA_H

--- a/CityProject/district.cpp
+++ b/CityProject/district.cpp
@@ -1,6 +1,9 @@
 #include "district.h"
 
-District::District()
+District::District(int c, int r, float rsw, float rsd) :
+    colOnSurface(c),
+    rowOnSurface(r),
+    center(QVector3D((c * rsw) + (rsw / 2), 0, (r * rsd) + (rsd / 2))) // Center of area [c ; r] on city surface
 {
 
 }

--- a/CityProject/district.h
+++ b/CityProject/district.h
@@ -1,11 +1,16 @@
 #ifndef DISTRICT_H
 #define DISTRICT_H
 
+#include <QVector3D>
 
 class District
 {
 public:
-    District();
+    District(int c, int r, float rsw, float rsd);
+
+protected:
+    int colOnSurface, rowOnSurface;
+    QVector3D center;
 };
 
 #endif // DISTRICT_H

--- a/CityProject/downtown.cpp
+++ b/CityProject/downtown.cpp
@@ -1,6 +1,7 @@
 #include "downtown.h"
 
-Downtown::Downtown()
+Downtown::Downtown(int c, int r, float rsw, float rsd) :
+    District (c, r, rsw, rsd)
 {
 
 }

--- a/CityProject/downtown.h
+++ b/CityProject/downtown.h
@@ -6,7 +6,7 @@
 class Downtown : public District
 {
 public:
-    Downtown();
+    Downtown(int c, int r, float rsw, float rsd);
 };
 
 #endif // DOWNTOWN_H

--- a/CityProject/factory.cpp
+++ b/CityProject/factory.cpp
@@ -1,0 +1,18 @@
+#include "factory.h"
+
+#include "squaredbuilding.h"
+#include "circularbuilding.h"
+
+#include <iostream>
+
+Factory::Factory(QVector3D center) : Building(1, 5, 5, 10, 5, 10, center)
+{
+    int prob = rand() % 101;
+    if(prob >= 0 && prob <= 49){
+        std::cout << "Squared Factory (" << prob << ")" << std::endl;
+        shapeGeometry = new SquaredBuilding(getWidth(), getHeight(), getDepth(), center);
+    }else{
+        std::cout << "Cylinder Factory (" << prob << ")" << std::endl;
+        shapeGeometry = new CircularBuilding(getWidth(), getHeight(), getDepth(), center);
+    }
+}

--- a/CityProject/factory.h
+++ b/CityProject/factory.h
@@ -1,0 +1,14 @@
+#ifndef FACTORY_H
+#define FACTORY_H
+
+
+#include "building.h"
+
+class Factory : public Building
+{
+private :
+public:
+    Factory(QVector3D center);
+};
+
+#endif // FACTORY_H

--- a/CityProject/gridsurfacedialog.cpp
+++ b/CityProject/gridsurfacedialog.cpp
@@ -5,18 +5,14 @@
 #include <QScrollBar>
 #include <iostream>
 
-GridSurfaceDialog::GridSurfaceDialog(int cityWidth, int cityDepth, int nbGridCol, int nbGridRow, QWidget *parent) :
+GridSurfaceDialog::GridSurfaceDialog(int nbGridCol, int nbGridRow, float rsww, float rsdd, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::GridSurfaceDialog),
     dimCubeSelection_(0),
-    cubeDim_(10)
+    cubeDim_(15)
 {
-    //One rectangle covers rectSurfaceWidth_ * rectSurfaceDepth_ area on city surface.
-    rectSurfaceWidth_ = float(cityWidth) / float(nbGridCol);
-    rectSurfaceDepth_ = float(cityDepth) / float(nbGridRow);
-
-    QString rsw = QString::number(rectSurfaceWidth_);
-    QString rsd = QString::number(rectSurfaceDepth_);
+    QString rsw = QString::number(double(rsww));
+    QString rsd = QString::number(double(rsdd));
 
     ui->setupUi(this);
 
@@ -75,17 +71,17 @@ void GridSurfaceDialog::modifyGridColors(int x, int y){
     int rowmin = row - dimCubeSelection_;
     rowmin = rowmin < 0 ? 0 : rowmin;
     int rowmax = row + dimCubeSelection_;
-    rowmax = rowmax >= grid_.at(0).size() ? grid_.at(0).size() - 1 : rowmax;
+    rowmax = rowmax >= int(grid_.at(0).size()) ? int(grid_.at(0).size()) - 1 : rowmax;
     int colmin = col - dimCubeSelection_;
     colmin = colmin < 0 ? 0 : colmin;
     int colmax = col + dimCubeSelection_;
-    colmax = colmax >= grid_.size() ? grid_.size() - 1 : colmax;
+    colmax = colmax >= int(grid_.size()) ? int(grid_.size()) - 1 : colmax;
 
     // Change grid area selected to current color, if needed.
     for(int c = colmin; c <= colmax; c++){
         for(int r = rowmin; r <= rowmax; r++){
-            QBrush b = grid_.at(c).at(r)->brush();
-            if(b != currBrush_) grid_.at(c).at(r)->setBrush(currBrush_);
+            QBrush b = grid_.at(ulong(c)).at(ulong(r))->brush();
+            if(b != currBrush_) grid_.at(ulong(c)).at(ulong(r))->setBrush(currBrush_);
         }
     }
 }

--- a/CityProject/gridsurfacedialog.h
+++ b/CityProject/gridsurfacedialog.h
@@ -16,7 +16,7 @@ class GridSurfaceDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit GridSurfaceDialog(int cityWidth, int cityDepth, int nbGridRow, int nbGridCol, QWidget *parent = nullptr);
+    explicit GridSurfaceDialog(int nbGridRow, int nbGridCol, float rsw, float rsd, QWidget *parent = nullptr);
     ~GridSurfaceDialog();
 
 private:
@@ -26,7 +26,6 @@ private:
     QGraphicsScene *scene;
     std::vector<std::vector<QGraphicsRectItem *>> grid_;
     QBrush currBrush_;
-    float rectSurfaceWidth_, rectSurfaceDepth_;
     int dimCubeSelection_;
     int cubeDim_;
 

--- a/CityProject/mainwindow.cpp
+++ b/CityProject/mainwindow.cpp
@@ -16,6 +16,16 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     twin = nullptr;
     gswin = nullptr;
+    cityWidth_ = ui->cityWidth->value();
+    cityDepth_ = ui->cityDepth->value();
+    nbDistrictsCols_ = ui->nbDistrictsCols->value();
+    nbDistrictsRows_ = ui->nbDistrictsRows->value();
+    rsw_ = cityWidth_ / nbDistrictsCols_;
+    rsd_ = cityDepth_ / nbDistrictsRows_;
+    connect(this, &MainWindow::surfaceLoaded,
+            this, &MainWindow::on_MainWindow_surfaceLoaded);
+    connect(this, &MainWindow::surfaceNotLoaded,
+            this, &MainWindow::on_MainWindow_surfaceNotLoaded);
 }
 
 MainWindow::~MainWindow()
@@ -51,24 +61,104 @@ void MainWindow::on_actionBuildingWin_triggered()
     twin->show();
 }
 
+void MainWindow::fillSurfaceGrid(int nbRow, int nbCol, int choice){
+    for(int i = 0; i < nbCol; i++){
+        std::vector<District *> col;
+        for(int j = 0; j < nbRow; j++){
+            if(choice == 1){
+                col.push_back(new Downtown(i, j, rsw_, rsd_));
+            }else{
+                if(choice == 2){
+                    col.push_back(new Periphery(i, j, rsw_, rsd_));
+                }else{
+                    if(choice == 3){
+                        col.push_back(new ActivityArea(i, j, rsw_, rsd_));
+                    }else{
+                        std::cout << "Invalid value, can't fill surface grid." << std::endl;
+                        return;
+                    }
+                }
+            }
+        }
+        surfaceGrid_.push_back(col);
+    }
+    emit surfaceLoaded();
+}
+
+// Fill the surface grid with a concentric pattern, so it will look like this :
+// (A : ActivityArea, P : Periphery, D : Downtown)
+//  A A A A A
+//  A P P P A
+//  A P D P A
+//  A P P P A
+//  A A A A A
+void MainWindow::fillConcentricSurfaceGrid(int nbRow, int nbCol){
+    // Compute column and row layer for this pattern (5 layers per column and 5 layers per row)
+    int areaSizeCol = nbCol / 5;
+    int areaSizeRow = nbRow / 5;
+
+    for(int i = 0; i < nbCol; i++){
+        std::vector<District *> col;
+        for(int j = 0; j < nbRow; j++){
+            bool found = false;
+            if((j < areaSizeRow) || (j >= (4 * areaSizeRow))){
+                 col.push_back(new ActivityArea(i, j, rsw_, rsd_));
+                 found = true;
+            }
+            if((i < areaSizeCol) || (i >= (4 * areaSizeCol))){
+                if(!found){
+                    col.push_back(new ActivityArea(i, j, rsw_, rsd_));
+                    found = true;
+                }
+            }
+            if((j >= areaSizeRow && j < (2 * areaSizeRow)) || (j < (4 * areaSizeRow) && j >= (3 * areaSizeRow))){
+                if(!found){
+                    col.push_back(new Periphery(i, j, rsw_, rsd_));
+                    found = true;
+                }
+            }
+            if((i >= areaSizeCol && i < (2 * areaSizeCol)) || (i < (4 * areaSizeCol) && i >= (3 * areaSizeCol))){
+                if(!found){
+                    col.push_back(new Periphery(i, j, rsw_, rsd_));
+                    found = true;
+                }
+            }
+            if(!found){
+                col.push_back(new Downtown(i, j, rsw_, rsd_));
+            }
+        }
+        surfaceGrid_.push_back(col);
+    }
+    emit surfaceLoaded();
+}
+
 void MainWindow::on_comboBox_activated(int index)
 {
     switch(index){
         case 0: // "Concentrique" option
-            std::cout << "Concentrique : not implemented yet." << std::endl;
+            if(gswin != nullptr) gswin->close();
+            emit surfaceNotLoaded();
+            fillConcentricSurfaceGrid(nbDistrictsRows_, nbDistrictsCols_);
             break;
         case 1: // "100 % Centre-ville" option
-            std::cout << "100 % Centre-ville : not implemented yet." << std::endl;
+            if(gswin != nullptr) gswin->close();
+            emit surfaceNotLoaded();
+            fillSurfaceGrid(nbDistrictsRows_, nbDistrictsCols_, index);
             break;
         case 2: // "100 % Périphérie" option
-            std::cout << "100 % Périphérie : not implemented yet." << std::endl;
+            if(gswin != nullptr) gswin->close();
+            emit surfaceNotLoaded();
+            fillSurfaceGrid(nbDistrictsRows_, nbDistrictsCols_, index);
             break;
         case 3: // "100 % ZA" option
-            std::cout << "100 % ZA : not implemented yet." << std::endl;
+            if(gswin != nullptr) gswin->close();
+            emit surfaceNotLoaded();
+            fillSurfaceGrid(nbDistrictsRows_, nbDistrictsCols_, index);
             break;
         case 4: // "Personnalisée..." option
             if(gswin != nullptr) gswin->close();
-            gswin = new GridSurfaceDialog(1000, 1000, 75, 75);
+            emit surfaceNotLoaded();
+            gswin = new GridSurfaceDialog(nbDistrictsRows_, nbDistrictsCols_, rsw_, rsd_);
             connect(gswin, &GridSurfaceDialog::sendSurfaceData,
                     this, &MainWindow::on_GridSurfaceDialog_sendSurfaceData);
             gswin->show();
@@ -77,26 +167,58 @@ void MainWindow::on_comboBox_activated(int index)
 }
 
 void MainWindow::on_GridSurfaceDialog_sendSurfaceData(std::vector<std::vector<QGraphicsRectItem *>> grid){
-    //Don't forget to erase old surfaceGrid_ if there's an existing one.
-    surfaceGrid_.erase(surfaceGrid_.begin(), surfaceGrid_.end());
-
     for(ulong i = 0; i < grid.size(); i++){
         std::vector<District *> col;
         for(ulong j = 0; j < grid.at(i).size(); j++){
             QGraphicsRectItem * rec = grid.at(i).at(j);
             QBrush rb = rec->brush();
             if(rb.color() == Qt::green){
-                col.push_back(new Periphery());
+                col.push_back(new Periphery(int(i), int(j), rsw_, rsd_));
             }else{
                 if(rb.color() == Qt::red){
-                    col.push_back(new Downtown());
+                    col.push_back(new Downtown(int(i), int(j), rsw_, rsd_));
                 }else{
-                    col.push_back(new ActivityArea());
+                    col.push_back(new ActivityArea(int(i), int(j), rsw_, rsd_));
                 }
             }
         }
         surfaceGrid_.push_back(col);
     }
+    emit surfaceLoaded();
+}
 
+void MainWindow::on_MainWindow_surfaceLoaded(){
     std::cout << "Surface grid loaded successfully." << std::endl;
+    ui->cityButton->setEnabled(true);
+}
+
+void MainWindow::on_MainWindow_surfaceNotLoaded(){
+    //Don't forget to erase old surfaceGrid_ if there's an existing one.
+    surfaceGrid_.erase(surfaceGrid_.begin(), surfaceGrid_.end());
+
+    ui->cityButton->setEnabled(false);
+}
+
+void MainWindow::on_cityWidth_valueChanged(int arg1)
+{
+    cityWidth_ = arg1;
+    rsw_ = cityWidth_ / nbDistrictsCols_;
+}
+
+void MainWindow::on_cityDepth_valueChanged(int arg1)
+{
+    cityDepth_ = arg1;
+    rsd_ = cityDepth_ / nbDistrictsRows_;
+}
+
+void MainWindow::on_nbDistrictsCols_valueChanged(int arg1)
+{
+    nbDistrictsCols_ = arg1;
+    rsw_ = cityWidth_ / nbDistrictsCols_;
+}
+
+void MainWindow::on_nbDistrictsRows_valueChanged(int arg1)
+{
+    nbDistrictsRows_ = arg1;
+    rsd_ = cityDepth_ / nbDistrictsRows_;
 }

--- a/CityProject/mainwindow.h
+++ b/CityProject/mainwindow.h
@@ -22,17 +22,31 @@ public:
 
 private slots:
     void on_actionBuildingWin_triggered();
-
     void on_comboBox_activated(int index);
+    void on_MainWindow_surfaceLoaded();
+    void on_MainWindow_surfaceNotLoaded();
+    void on_cityWidth_valueChanged(int arg1);
+    void on_nbDistrictsCols_valueChanged(int arg1);
+    void on_nbDistrictsRows_valueChanged(int arg1);
+    void on_cityDepth_valueChanged(int arg1);
+
+signals :
+    void surfaceLoaded();
+    void surfaceNotLoaded();
 
 public slots:
     void on_GridSurfaceDialog_sendSurfaceData(std::vector<std::vector<QGraphicsRectItem *>>);
 
 private:
+    void fillSurfaceGrid(int nbRow, int nbCol, int choice);
+    void fillConcentricSurfaceGrid(int nbRow, int nbCol);
+
     Ui::MainWindow *ui;
     baseGLWidget * twin;
     GridSurfaceDialog * gswin;
     std::vector<std::vector<District *>> surfaceGrid_;
+    int cityWidth_, cityDepth_, nbDistrictsCols_, nbDistrictsRows_;
+    float rsw_, rsd_;
 };
 
 #endif // MAINWINDOW_H

--- a/CityProject/mainwindow.ui
+++ b/CityProject/mainwindow.ui
@@ -62,7 +62,10 @@
      <string>Surface de la ville :</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="pushButton">
+   <widget class="QPushButton" name="cityButton">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
     <property name="geometry">
      <rect>
       <x>140</x>
@@ -73,6 +76,147 @@
     </property>
     <property name="text">
      <string>Générer ville !</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>20</y>
+      <width>81</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>City Width :</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_3">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>60</y>
+      <width>81</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>City Depth :</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_4">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>100</y>
+      <width>161</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Districts on all surface :</string>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="cityWidth">
+    <property name="geometry">
+     <rect>
+      <x>120</x>
+      <y>20</y>
+      <width>101</width>
+      <height>26</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>10000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="cityDepth">
+    <property name="geometry">
+     <rect>
+      <x>120</x>
+      <y>60</y>
+      <width>101</width>
+      <height>26</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>10000</number>
+    </property>
+    <property name="value">
+     <number>1000</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_5">
+    <property name="geometry">
+     <rect>
+      <x>180</x>
+      <y>100</y>
+      <width>91</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Width (Cols) :</string>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="nbDistrictsCols">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>100</y>
+      <width>48</width>
+      <height>26</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>100</number>
+    </property>
+    <property name="value">
+     <number>75</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_6">
+    <property name="geometry">
+     <rect>
+      <x>180</x>
+      <y>130</y>
+      <width>101</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Depth (Rows) :</string>
+    </property>
+   </widget>
+   <widget class="QSpinBox" name="nbDistrictsRows">
+    <property name="geometry">
+     <rect>
+      <x>290</x>
+      <y>130</y>
+      <width>48</width>
+      <height>26</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>100</number>
+    </property>
+    <property name="value">
+     <number>75</number>
     </property>
    </widget>
   </widget>

--- a/CityProject/periphery.cpp
+++ b/CityProject/periphery.cpp
@@ -1,6 +1,7 @@
 #include "periphery.h"
 
-Periphery::Periphery()
+Periphery::Periphery(int c, int r, float rsw, float rsd) :
+    District(c, r, rsw, rsd)
 {
 
 }

--- a/CityProject/periphery.h
+++ b/CityProject/periphery.h
@@ -6,7 +6,7 @@
 class Periphery : public District
 {
 public:
-    Periphery();
+    Periphery(int c, int r, float rsw, float rsd);
 };
 
 #endif // PERIPHERY_H


### PR DESCRIPTION
- L'interface de la fenêtre principale a été mise à jour : l'utilisateur peut désormais entrer les dimensions de la ville, le nombre de quartiers s'étendant sur la largeur de la surface de la ville et le nombre de quartiers s'étendant sur la profondeur de la ville.

- Implémentation des options surface suivantes : "100 % Périphérie", "100 % ZA", "100 % Centre-ville" et "Surface concentrique"

- Mise à jour des classes quartiers (District, Downtown, Periphery et ActivityArea) avec de nouveaux attributs nécessaires pour le travail de l'après-midi.

- Ajout de la classe Factory, représentant les usines, pour le type de quartier Zone d'activités.

_ POUR CET APREM _

- Complétion des classes surface (probabilités d'apparition de bâtiments selon le type de quartier, etc...)
- Afficher la ville, avec sa surface et les bâtiments dessus.
- Une fois le point ci-dessus réalisé, empêcher l'affichage d'un baiment si un autre occupe l'espace où il devrait apparaître.
- Essayer d'afficher les routes, si j'ai le temps.