### PR TITLE
[09-01, aprem] Affichage fenêtre ville

### DIFF
--- a/CityProject/activityarea.cpp
+++ b/CityProject/activityarea.cpp
@@ -3,5 +3,8 @@
 ActivityArea::ActivityArea(int c, int r, float rsw, float rsd) :
     District (c, r, rsw, rsd)
 {
-
+    probHouse = 15;
+    probFactory = 85;
+    probTower = 0;
+    generateBuilding();
 }

--- a/CityProject/baseglwidget.cpp
+++ b/CityProject/baseglwidget.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <cmath>
 
-baseGLWidget::baseGLWidget(std::vector<baseGeometry *> glist, QWidget* parent)
+baseGLWidget::baseGLWidget(std::vector<baseGeometry *> & glist, QWidget* parent)
  : QOpenGLWidget( parent ),
    geos_(glist)
 {
@@ -43,7 +43,7 @@ void baseGLWidget::resizeGL( int w, int h )
     // Calculate aspect ratio
     qreal aspect = qreal(w) / qreal(h ? h : 1);
 
-    // Set near plane to 0.001, far plane to 1500.0, field of view 45 degrees
+    // Set near plane to 0.001, far plane to 300.0, field of view 45 degrees
     const qreal zNear = 0.001, zFar = 1500.0, fov = 45.0;
 
     // Reset projection
@@ -120,8 +120,10 @@ void baseGLWidget::keyPressEvent( QKeyEvent* e )
             cameraTarget_.setY(cameraTarget_.y() + pas);
             break;
         case Qt::Key_Down: // Translate : Down
-            cameraPos_.setY(cameraPos_.y() - pas);
-            cameraTarget_.setY(cameraTarget_.y() - pas);
+            if(cameraPos_.y() - pas >= 0.1f){
+                cameraPos_.setY(cameraPos_.y() - pas);
+                cameraTarget_.setY(cameraTarget_.y() - pas);
+            }
             break;
         case Qt::Key_Right: // Rotate : Right
             rotateAngleY_ += rotateSpeed;

--- a/CityProject/baseglwidget.h
+++ b/CityProject/baseglwidget.h
@@ -14,7 +14,7 @@ class baseGLWidget : public QOpenGLWidget, protected QOpenGLFunctions
 {
  Q_OBJECT
 public:
-    baseGLWidget(std::vector<baseGeometry *> glist, QWidget* parent = nullptr );
+    baseGLWidget(std::vector<baseGeometry *> & glist, QWidget* parent = nullptr );
 
 protected:
     virtual void initializeGL();

--- a/CityProject/district.cpp
+++ b/CityProject/district.cpp
@@ -1,9 +1,30 @@
 #include "district.h"
+#include "house.h"
+#include "factory.h"
+#include "tower.h"
+
+#include <iostream>
 
 District::District(int c, int r, float rsw, float rsd) :
     colOnSurface(c),
     rowOnSurface(r),
-    center(QVector3D((c * rsw) + (rsw / 2), 0, (r * rsd) + (rsd / 2))) // Center of area [c ; r] on city surface
+    center(QVector3D(c * rsw, 0, r * rsd)) // Center of area [c ; r] on city surface
 {
+}
 
+void District::generateBuilding(){
+    if(probHouse + probTower + probFactory > 100) return;
+    int prob = rand() % 101;
+    if(prob >= 0 && prob <= probHouse){
+        Building * b = new House(center);
+        building = b->getShapeGeometry();
+    }else{
+        if(prob > probHouse && prob <= probHouse + probTower){
+            Building * b = new Tower(center);
+            building = b->getShapeGeometry();
+        }else{
+            Building * b = new Factory(center);
+            building = b->getShapeGeometry();
+        }
+    }
 }

--- a/CityProject/district.h
+++ b/CityProject/district.h
@@ -1,16 +1,22 @@
 #ifndef DISTRICT_H
 #define DISTRICT_H
 
+#include "basegeometry.h"
 #include <QVector3D>
 
 class District
 {
 public:
     District(int c, int r, float rsw, float rsd);
+    baseGeometry * getBuilding(){ return building; }
 
 protected:
     int colOnSurface, rowOnSurface;
     QVector3D center;
+
+    int probHouse, probTower, probFactory;
+    baseGeometry * building;
+    void generateBuilding();
 };
 
 #endif // DISTRICT_H

--- a/CityProject/downtown.cpp
+++ b/CityProject/downtown.cpp
@@ -3,5 +3,8 @@
 Downtown::Downtown(int c, int r, float rsw, float rsd) :
     District (c, r, rsw, rsd)
 {
-
+    probTower = 80;
+    probHouse = 10;
+    probFactory = 10;
+    generateBuilding();
 }

--- a/CityProject/factory.cpp
+++ b/CityProject/factory.cpp
@@ -8,6 +8,7 @@
 Factory::Factory(QVector3D center) : Building(1, 5, 5, 10, 5, 10, center)
 {
     int prob = rand() % 101;
+    center.setY(getHeight());
     if(prob >= 0 && prob <= 49){
         std::cout << "Squared Factory (" << prob << ")" << std::endl;
         shapeGeometry = new SquaredBuilding(getWidth(), getHeight(), getDepth(), center);

--- a/CityProject/gridsurfacedialog.cpp
+++ b/CityProject/gridsurfacedialog.cpp
@@ -9,7 +9,7 @@ GridSurfaceDialog::GridSurfaceDialog(int nbGridCol, int nbGridRow, float rsww, f
     QDialog(parent),
     ui(new Ui::GridSurfaceDialog),
     dimCubeSelection_(0),
-    cubeDim_(15)
+    cubeDim_(30)
 {
     QString rsw = QString::number(double(rsww));
     QString rsd = QString::number(double(rsdd));
@@ -17,6 +17,7 @@ GridSurfaceDialog::GridSurfaceDialog(int nbGridCol, int nbGridRow, float rsww, f
     ui->setupUi(this);
 
     scene = new QGraphicsScene(this);
+    ui->graphicsView->setAlignment(Qt::AlignTop | Qt::AlignLeft);
     ui->graphicsView->setScene(scene);
     ui->gridInfo->setText("Info : One rectangle in grid = one area in city's surface area, dimensions : " + rsw + " * " + rsd);
 

--- a/CityProject/house.cpp
+++ b/CityProject/house.cpp
@@ -7,6 +7,7 @@
 House::House(QVector3D center) : Building(1, 5, 1, 5, 1, 5, center)
 {
     int prob = rand() % 101;
+    center.setY(getHeight());
     if(prob >= 0 && prob <= 49){
         std::cout << "Squared House (" << prob << ")" << std::endl;
         shapeGeometry = new SquaredBuilding(getWidth(), getHeight(), getDepth(), center);

--- a/CityProject/mainwindow.ui
+++ b/CityProject/mainwindow.ui
@@ -130,7 +130,7 @@
      <number>1</number>
     </property>
     <property name="maximum">
-     <number>10000</number>
+     <number>1500</number>
     </property>
     <property name="value">
      <number>1000</number>
@@ -149,7 +149,7 @@
      <number>1</number>
     </property>
     <property name="maximum">
-     <number>10000</number>
+     <number>1500</number>
     </property>
     <property name="value">
      <number>1000</number>
@@ -181,10 +181,10 @@
      <number>1</number>
     </property>
     <property name="maximum">
-     <number>100</number>
+     <number>20</number>
     </property>
     <property name="value">
-     <number>75</number>
+     <number>10</number>
     </property>
    </widget>
    <widget class="QLabel" name="label_6">
@@ -213,10 +213,10 @@
      <number>1</number>
     </property>
     <property name="maximum">
-     <number>100</number>
+     <number>20</number>
     </property>
     <property name="value">
-     <number>75</number>
+     <number>10</number>
     </property>
    </widget>
   </widget>

--- a/CityProject/periphery.cpp
+++ b/CityProject/periphery.cpp
@@ -3,5 +3,8 @@
 Periphery::Periphery(int c, int r, float rsw, float rsd) :
     District(c, r, rsw, rsd)
 {
-
+    probHouse = 85;
+    probFactory = 15;
+    probTower = 0;
+    generateBuilding();
 }

--- a/CityProject/shaders/surface.frag
+++ b/CityProject/shaders/surface.frag
@@ -1,0 +1,12 @@
+#version 300 es
+#undef lowp
+#undef mediump
+#undef highp
+
+precision mediump float;
+
+out vec4 color;
+
+void main(){
+  color = vec4( 0.8 , 0.8 , 0.8 , 1 );
+}

--- a/CityProject/tower.cpp
+++ b/CityProject/tower.cpp
@@ -8,6 +8,7 @@
 Tower::Tower(QVector3D center) : Building(5, 20, 1, 5, 1, 5, center)
 {
     int prob = rand() % 101;
+    center.setY(getHeight());
     if(prob >= 0 && prob <= 33){
         std::cout << "Squared Tower (" << prob << ")" << std::endl;
         shapeGeometry = new SquaredBuilding(getWidth(), getHeight(), getDepth(), center);


### PR DESCRIPTION
- En appuyant sur le bouton "Générer ville" dans la fenêtre principale après avoir sélectionné les dimensions de la ville et le découpage en quartiers, une fenêtre baseOpenGLWidget s'affiche, permettant de comtempler la ville.

- Réduction des valeurs maximum possible pour les dimensions de la ville et le nombre de quartiers s'étalant sur la largeur et la profondeur de la ville (voir ci-dessous pour plus d'infos)

- Correction de bugs mineurs.

_ TO_DO (si j'ai le temps demain à côté du diapo à faire :/) _

- Permettre l'affichage de plus de bâtiments sur la fenêtre ville (actuellement, si on va au delà de 20 * 20 districts (soit 400 bâtiments), le temps d'affichage de la fenêtre ville est particulièrement long, avec un FPS nul (impossible de bouger dans l'espace)) : revenir donc aux valeurs max avant cette version serait nickel (taille ville : 10000, découpage en quartiers : 75).

- Empêcher la collision de bâtiments

- Inclure les routes.